### PR TITLE
Correct regex and assign output of withPath

### DIFF
--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -89,7 +89,7 @@ class Normalizer
             }
 
             if ($flags & self::REDUCE_DUPLICATE_PATH_SLASHES) {
-                $uri = $uri->withPath(preg_replace('#//++#', '/', $uri->getPath()));
+                $uri = $uri->withPath((string) preg_replace('#//++#', '/', $uri->getPath()));
             }
 
             if ($flags & self::ADD_PATH_TRAILING_SLASH) {

--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -89,7 +89,7 @@ class Normalizer
             }
 
             if ($flags & self::REDUCE_DUPLICATE_PATH_SLASHES) {
-                $uri->withPath((string) preg_replace('#//++#', '/', $uri->getPath()));
+                $uri = $uri->withPath(preg_replace('#//++#', '/', $uri->getPath()));
             }
 
             if ($flags & self::ADD_PATH_TRAILING_SLASH) {

--- a/tests/NormalizerTest.php
+++ b/tests/NormalizerTest.php
@@ -322,7 +322,7 @@ class NormalizerTest extends \PHPUnit\Framework\TestCase
             ],
             'reduceDuplicatePathSlashes: has duplicate slashes' => [
                 'url' => 'http://example.com//path//',
-                'expectedUrl' => 'http://example.com//path//',
+                'expectedUrl' => 'http://example.com/path/',
                 'flags' => Normalizer::REDUCE_DUPLICATE_PATH_SLASHES,
             ],
         ];


### PR DESCRIPTION
The regex had an extra "+" and the result of withPath was not assigned back to `$uri`, so `REDUCE_DUPLICATE_PATH_SLASHES` did nothing.