### PR TITLE
Docs: remove installation guide version constraint

### DIFF
--- a/docs/requirements-and-installation.rst
+++ b/docs/requirements-and-installation.rst
@@ -17,4 +17,4 @@ Installation
 
 .. code-block:: bash
 
-    composer require webignition/uri ^1
+    composer require webignition/uri


### PR DESCRIPTION
The provided version constraint (^1) does not exist, preventing installation based on this guide. Removed to let composer pick the latest compatible version.