### PR TITLE
Package Dependency Updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require": {
         "php": "^7.4|^8.0|^8.1",
-        "psr/http-message": "^1",
+        "psr/http-message": "^1 || ^2.0",
         "algo26-matthias/idna-convert": "^3.0",
         "xrstf/ip-utils": "^1.1"
     },


### PR DESCRIPTION
Add support for psr/http-message ^2.0 for compatibility with modern packages
Replace ip-utils package as hookedmedia/ip-utils is suddenly dead, xrstf/ip-utils is new/identical package name
